### PR TITLE
explicitly mention "Parser Compatibility"

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 - Passes all microformats2 tests from [the official test suite](https://github.com/microformats/tests)¹
 - Supports Ruby 2.5 and newer
 
-**Note:** MicroMicro **does not** parse [Classic Microformats](http://microformats.org/wiki/Main_Page#Classic_Microformats) (referred to in [the parsing specification](http://microformats.org/wiki/microformats2-parsing#note_backward_compatibility_details) as "backcompat root classes" and "backcompat properties"). If parsing documents marked up in this fashion, consider using [the official microformats-ruby parser](https://github.com/microformats/microformats-ruby).
+**Note:** MicroMicro **does not** parse [Classic Microformats](http://microformats.org/wiki/Main_Page#Classic_Microformats) (referred to in [the parsing specification](http://microformats.org/wiki/microformats2-parsing#note_backward_compatibility_details) as "backcompat root classes" and "backcompat properties", and as "Parser Compatibility" in the vocabulary specifications e.g. [h-entry Parser Compatibility](https://microformats.org/wiki/h-entry#Parser_Compatibility)). To parse documents marked up with Classic Microformats, consider using [the official microformats-ruby parser](https://github.com/microformats/microformats-ruby).
 
 <small>¹ …with some exceptions until [this pull request](https://github.com/microformats/tests/pull/112) is merged.</small>
 


### PR DESCRIPTION
note "Parser Compatibility" as phrase used by vocab specs as what's not supported, slight rephrase of subsequent sentence