### PR TITLE
Address RuboCop Performance warnings

### DIFF
--- a/lib/micro_micro/collections/items_collection.rb
+++ b/lib/micro_micro/collections/items_collection.rb
@@ -58,7 +58,7 @@ module MicroMicro
       #
       # @return [Array<String>]
       def types
-        @types ||= flat_map(&:types).uniq.sort
+        @types ||= Set[*flat_map(&:types)].to_a.sort
       end
 
       # Recursively search this collection for {MicroMicro::Item}s matching the

--- a/lib/micro_micro/collections/properties_collection.rb
+++ b/lib/micro_micro/collections/properties_collection.rb
@@ -37,7 +37,7 @@ module MicroMicro
       #
       # @return [Array<String>]
       def names
-        @names ||= map(&:name).uniq.sort
+        @names ||= Set[*map(&:name)].to_a.sort
       end
 
       # A collection of plain text {MicroMicro::Property}s parsed from the node.

--- a/lib/micro_micro/collections/properties_collection.rb
+++ b/lib/micro_micro/collections/properties_collection.rb
@@ -91,7 +91,7 @@ module MicroMicro
       #
       # @return [Array<String, Hash>]
       def values
-        @values ||= map(&:value).uniq
+        @values ||= Set[*map(&:value)].to_a
       end
 
       # Search this collection for {MicroMicro::Property}s matching the given

--- a/lib/micro_micro/collections/relationships_collection.rb
+++ b/lib/micro_micro/collections/relationships_collection.rb
@@ -62,7 +62,7 @@ module MicroMicro
       #
       # @return [Array<String>]
       def rels
-        @rels ||= flat_map(&:rels).uniq.sort
+        @rels ||= Set[*flat_map(&:rels)].to_a.sort
       end
 
       # Retrieve an Array of this collection's unique {MicroMicro::Relationship}
@@ -72,7 +72,7 @@ module MicroMicro
       #
       # @return [Array<String>]
       def urls
-        @urls ||= map(&:href).uniq.sort
+        @urls ||= Set[*map(&:href)].to_a.sort
       end
 
       # Search this collection for {MicroMicro::Relationship}s matching the

--- a/lib/micro_micro/helpers.rb
+++ b/lib/micro_micro/helpers.rb
@@ -54,7 +54,7 @@ module MicroMicro
     # @param node [Nokogiri::XML::Element]
     # @return [Array<String>]
     def self.root_class_names_from(node)
-      node.classes.grep(/^h(?:-[0-9a-z]+)?(?:-[a-z]+)+$/).uniq.sort
+      Set[*node.classes.grep(/^h(?:-[0-9a-z]+)?(?:-[a-z]+)+$/)].to_a.sort
     end
 
     # @see https://microformats.org/wiki/microformats2-parsing#parse_an_element_for_properties

--- a/lib/micro_micro/parsers/implied_name_property_parser.rb
+++ b/lib/micro_micro/parsers/implied_name_property_parser.rb
@@ -24,7 +24,7 @@ module MicroMicro
         [
           node.at_css("> :only-child"),
           node.at_css("> :only-child > :only-child")
-        ].compact.reject { |child_node| Helpers.item_node?(child_node) }
+        ].reject { |child_node| child_node.nil? || Helpers.item_node?(child_node) }
       end
 
       # @return [String]

--- a/lib/micro_micro/parsers/implied_photo_property_parser.rb
+++ b/lib/micro_micro/parsers/implied_photo_property_parser.rb
@@ -35,7 +35,7 @@ module MicroMicro
 
         nodes << node.first_element_child.at_css(*CSS_SELECTORS_ARRAY) if node.element_children.one?
 
-        nodes.compact.reject { |child_node| Helpers.item_node?(child_node) }
+        nodes.reject { |child_node| child_node.nil? || Helpers.item_node?(child_node) }
       end
     end
   end

--- a/lib/micro_micro/parsers/implied_url_property_parser.rb
+++ b/lib/micro_micro/parsers/implied_url_property_parser.rb
@@ -26,7 +26,7 @@ module MicroMicro
 
         nodes << node.first_element_child.at_css(*CSS_SELECTORS_ARRAY) if node.element_children.one?
 
-        nodes.compact.reject { |child_node| Helpers.item_node?(child_node) }
+        nodes.reject { |child_node| child_node.nil? || Helpers.item_node?(child_node) }
       end
     end
   end

--- a/lib/micro_micro/relationship.rb
+++ b/lib/micro_micro/relationship.rb
@@ -11,8 +11,7 @@ module MicroMicro
     def self.from_context(context)
       context
         .css(%([href][rel]:not([rel=""])))
-        .reject { |node| Helpers.ignore_nodes?(node.ancestors) }
-        .map { |node| new(node) }
+        .filter_map { |node| new(node) unless Helpers.ignore_nodes?(node.ancestors) }
     end
 
     # Parse a node for relationship data.

--- a/lib/micro_micro/relationship.rb
+++ b/lib/micro_micro/relationship.rb
@@ -73,7 +73,7 @@ module MicroMicro
     #
     # @return [Array<String>]
     def rels
-      @rels ||= node["rel"].split.uniq.sort
+      @rels ||= Set[*node["rel"].split].to_a.sort
     end
 
     # The node's text content.


### PR DESCRIPTION
- Use `Set` instead of calling `Array#uniq`
- Use Set instead of calling `uniq` on a mapped Array
- RuboCop: Performance/ChainArrayAllocation
